### PR TITLE
Fix: App crash when server send an event without a message

### DIFF
--- a/android/src/main/java/com/itsclicking/clickapp/fluttersocketio/SocketListener.java
+++ b/android/src/main/java/com/itsclicking/clickapp/fluttersocketio/SocketListener.java
@@ -26,7 +26,7 @@ public class SocketListener implements Emitter.Listener {
         if (args != null && _methodChannel != null && !Utils.isNullOrEmpty(_event)
                 && !Utils.isNullOrEmpty(_callback)) {
             String data = "";
-            if (args[0] != null) {
+            if (args.length != 0 && args[0] != null) {
                 data = args[0].toString();
             }
             _methodChannel.invokeMethod(_socketId + "|" +_event + "|" + _callback, data);


### PR DESCRIPTION
When the server emits an event without a message or data, the app crashes. This piece of code solves it.