### PR TITLE
change android's getSocket access modifier to public

### DIFF
--- a/android/src/main/java/com/itsclicking/clickapp/fluttersocketio/ISocketIOManager.java
+++ b/android/src/main/java/com/itsclicking/clickapp/fluttersocketio/ISocketIOManager.java
@@ -14,4 +14,7 @@ public interface ISocketIOManager {
     void disconnect(String domain, String namespace);
     void destroySocket(String domain, String namespace);
     void destroyAllSockets();
+
+    String getSocketId(String domain, String namespace);
+    SocketIO getSocket(String socketId);
 }

--- a/android/src/main/java/com/itsclicking/clickapp/fluttersocketio/SocketIOManager.java
+++ b/android/src/main/java/com/itsclicking/clickapp/fluttersocketio/SocketIOManager.java
@@ -23,7 +23,7 @@ public class SocketIOManager implements ISocketIOManager {
         mSockets = new HashMap<>();
     }
 
-    private SocketIO getSocket(String socketId) {
+    public SocketIO getSocket(String socketId) {
         if(mSockets != null && !Utils.isNullOrEmpty(socketId)) {
             Utils.log("TOTAL SOCKETS: ", String.valueOf(mSockets.size()));
             return mSockets.get(socketId);
@@ -58,7 +58,7 @@ public class SocketIOManager implements ISocketIOManager {
         return socketIO != null && socketIO.isConnected();
     }
 
-    private String getSocketId(String domain, String namespace) {
+    public String getSocketId(String domain, String namespace) {
         if(!Utils.isNullOrEmpty(domain)) {
             return domain + (namespace != null ? namespace : "");
         }


### PR DESCRIPTION
Since `SocketIOManager` is singleton, it can be useful to use it directly in an android service and reuse already connected socket to transfer messages.
I just wanted to run
`SocketIOManager.getInstance().getSocket( socketId )`